### PR TITLE
Fix crash in moveit move_group_interface

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -104,7 +104,13 @@ public:
                          const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers)
     : opt_(opt), node_(node), tf_buffer_(tf_buffer)
   {
-    pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
+    // We have no control on how the passed node is getting executed. To make sure MGI is functional, we're creating
+    // our own callback group which is managed in a separate callback thread
+    callback_group_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive,
+                                                   false /* don't spin with node executor */);
+    callback_executor_.add_callback_group(callback_group_, node->get_node_base_interface());
+    callback_thread_ = std::thread([this]() { callback_executor_.spin(); });
+
     robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(node_, opt.robot_description_);
     if (!getRobotModel())
     {
@@ -144,14 +150,15 @@ public:
       end_effector_link_ = joint_model_group_->getLinkModelNames().back();
     pose_reference_frame_ = getRobotModel()->getModelFrame();
 
-    trajectory_event_publisher_ = pnode_->create_publisher<std_msgs::msg::String>(
+    trajectory_event_publisher_ = node_->create_publisher<std_msgs::msg::String>(
         trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC, 1);
-    attached_object_publisher_ = pnode_->create_publisher<moveit_msgs::msg::AttachedCollisionObject>(
+    attached_object_publisher_ = node_->create_publisher<moveit_msgs::msg::AttachedCollisionObject>(
         planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1);
 
     current_state_monitor_ = getSharedStateMonitor(node_, robot_model_, tf_buffer_);
 
-    move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(pnode_, move_group::MOVE_ACTION);
+    move_action_client_ =
+        rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(node_, move_group::MOVE_ACTION, callback_group_);
     move_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
     // TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
     // pick_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Pickup>(
@@ -161,21 +168,21 @@ public:
     //    place_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Place>(
     //        node_, move_group::PLACE_ACTION);
     //    place_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
-    execute_action_client_ =
-        rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(pnode_, move_group::EXECUTE_ACTION_NAME);
+    execute_action_client_ = rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(
+        node_, move_group::EXECUTE_ACTION_NAME, callback_group_);
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
 
-    query_service_ =
-        pnode_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);
-    get_params_service_ =
-        pnode_->create_client<moveit_msgs::srv::GetPlannerParams>(move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
-    set_params_service_ =
-        pnode_->create_client<moveit_msgs::srv::SetPlannerParams>(move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
+    query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
+        move_group::QUERY_PLANNERS_SERVICE_NAME, rmw_qos_profile_services_default, callback_group_);
+    get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
+        move_group::GET_PLANNER_PARAMS_SERVICE_NAME, rmw_qos_profile_services_default, callback_group_);
+    set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
+        move_group::SET_PLANNER_PARAMS_SERVICE_NAME, rmw_qos_profile_services_default, callback_group_);
 
     cartesian_path_service_ =
-        pnode_->create_client<moveit_msgs::srv::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
 
-    // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
+    // plan_grasps_service_ = node_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
     RCLCPP_INFO_STREAM(LOGGER, "Ready to take commands for planning group " << opt.group_name_ << ".");
   }
@@ -184,6 +191,13 @@ public:
   {
     if (constraints_init_thread_)
       constraints_init_thread_->join();
+
+    // executor.is_spinning() was added later - just cancel for now and hope it doesn't crash
+    // if (callback_executor_.is_spinning())
+    callback_executor_.cancel();
+
+    if (callback_thread_.joinable())
+      callback_thread_.join();
   }
 
   const std::shared_ptr<tf2_ros::Buffer>& getTF() const
@@ -217,7 +231,7 @@ public:
     auto future_response = query_service_->async_send_request(req);
 
     // wait until future is done
-    if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
+    if (future_response.valid())
     {
       const auto& response = future_response.get();
       if (!response->planner_interfaces.empty())
@@ -233,7 +247,7 @@ public:
   {
     auto req = std::make_shared<moveit_msgs::srv::QueryPlannerInterfaces::Request>();
     auto future_response = query_service_->async_send_request(req);
-    if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
+    if (future_response.valid())
     {
       const auto& response = future_response.get();
       if (!response->planner_interfaces.empty())
@@ -253,10 +267,10 @@ public:
     req->group = group;
     std::map<std::string, std::string> result;
 
-    auto res = get_params_service_->async_send_request(req);
-    if (rclcpp::spin_until_future_complete(pnode_, res) == rclcpp::FutureReturnCode::SUCCESS)
+    auto future_response = get_params_service_->async_send_request(req);
+    if (future_response.valid())
     {
-      response = res.get();
+      response = future_response.get();
       for (unsigned int i = 0, end = response->params.keys.size(); i < end; ++i)
         result[response->params.keys[i]] = response->params.values[i];
     }
@@ -789,7 +803,6 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      rclcpp::spin_some(pnode_);
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
@@ -869,7 +882,6 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      rclcpp::spin_some(pnode_);
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
@@ -939,7 +951,6 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      rclcpp::spin_some(pnode_);
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
@@ -974,10 +985,10 @@ public:
     req->avoid_collisions = avoid_collisions;
     req->link_name = getEndEffectorLink();
 
-    auto res = cartesian_path_service_->async_send_request(req);
-    if (rclcpp::spin_until_future_complete(pnode_, res) == rclcpp::FutureReturnCode::SUCCESS)
+    auto future_response = cartesian_path_service_->async_send_request(req);
+    if (future_response.valid())
     {
-      response = res.get();
+      response = future_response.get();
       error_code = response->error_code;
       if (response->error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
       {
@@ -1001,7 +1012,6 @@ public:
       std_msgs::msg::String event;
       event.data = "stop";
       trajectory_event_publisher_->publish(event);
-      rclcpp::spin_some(pnode_);
     }
   }
 
@@ -1028,7 +1038,6 @@ public:
       aco.touch_links = touch_links;
     aco.object.operation = moveit_msgs::msg::CollisionObject::ADD;
     attached_object_publisher_->publish(aco);
-    rclcpp::spin_some(pnode_);
     return true;
   }
 
@@ -1049,13 +1058,11 @@ public:
       {
         aco.link_name = lname;
         attached_object_publisher_->publish(aco);
-        rclcpp::spin_some(pnode_);
       }
     }
     else
     {
       attached_object_publisher_->publish(aco);
-      rclcpp::spin_some(pnode_);
     }
     return true;
   }
@@ -1358,7 +1365,9 @@ private:
 
   Options opt_;
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Node::SharedPtr pnode_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::executors::SingleThreadedExecutor callback_executor_;
+  std::thread callback_thread_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -192,8 +192,6 @@ public:
     if (constraints_init_thread_)
       constraints_init_thread_->join();
 
-    // executor.is_spinning() was added later - just cancel for now and hope it doesn't crash
-    // if (callback_executor_.is_spinning())
     callback_executor_.cancel();
 
     if (callback_thread_.joinable())


### PR DESCRIPTION
Fixed moveit crashes by porting fixes from PR [1250](https://github.com/ros-planning/moveit2/pull/1250), [1305](https://github.com/ros-planning/moveit2/pull/1305) and [1553](https://github.com/ros-planning/moveit2/pull/1553)